### PR TITLE
Fix Session.getCookies docs to return array

### DIFF
--- a/Session.js
+++ b/Session.js
@@ -926,7 +926,7 @@ Session.prototype = {
 	/**
 	 * Gets all cookies set on the current page.
 	 *
-	 * @returns {Promise.<WebDriverCookie>}
+	 * @returns {Promise.<WebDriverCookie[]>}
 	 */
 	getCookies: function () {
 		return this._get('cookie').then(function (cookies) {


### PR DESCRIPTION
Old: `@returns {Promise.<WebDriverCookie>}`

New: `@returns {Promise.<WebDriverCookie[]>}`