### PR TITLE
Rename Strategies to Strategy and use it in function signatures

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -2,7 +2,7 @@ import { sleep, trimStack } from './lib/util';
 import Element from './Element';
 import Task from '@dojo/core/async/Task';
 import Session from './Session';
-import Locator from './lib/Locator';
+import Locator, { Strategy } from './lib/Locator';
 import { LogEntry, Geolocation, WebDriverCookie } from './interfaces';
 
 /**
@@ -499,15 +499,15 @@ export default class Command<T> extends Locator<Command<Element>, Command<Elemen
 		return this;
 	}
 
-	find(strategy: string, value: string) {
+	find(strategy: Strategy, value: string) {
 		return this._callFindElementMethod<Element>('find', strategy, value);
 	}
 
-	findAll(strategy: string, value: string) {
+	findAll(strategy: Strategy, value: string) {
 		return this._callFindElementMethod<Element[]>('findAll', strategy, value);
 	}
 
-	findDisplayed(strategy: string, value: string) {
+	findDisplayed(strategy: Strategy, value: string) {
 		return this._callFindElementMethod<Element>('findDisplayed', strategy, value);
 	}
 
@@ -1256,7 +1256,7 @@ export default class Command<T> extends Locator<Command<Element>, Command<Elemen
 	 * @param value
 	 * The strategy-specific value to search for. See [[Command.find]] for details.
 	 */
-	waitForDeleted(using: string, value: string) {
+	waitForDeleted(using: Strategy, value: string) {
 		return this._callSessionMethod<void>('waitForDeleted', using, value);
 	}
 

--- a/src/Element.ts
+++ b/src/Element.ts
@@ -1,6 +1,6 @@
 import findDisplayed from './lib/findDisplayed';
 import * as fs from 'fs';
-import Locator, { toW3cLocator } from './lib/Locator';
+import Locator, { Strategy, toW3cLocator } from './lib/Locator';
 import waitForDeleted from './lib/waitForDeleted';
 import { sleep } from './lib/util';
 import Task from '@dojo/core/async/Task';
@@ -114,7 +114,7 @@ export default class Element extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	find(using: string, value: string): Task<Element> {
+	find(using: Strategy, value: string): Task<Element> {
 		const session = this._session;
 		const capabilities = session.capabilities;
 
@@ -165,7 +165,7 @@ export default class Element extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	findAll(using: string, value: string): Task<Element[]> {
+	findAll(using: Strategy, value: string): Task<Element[]> {
 		const session = this._session;
 		const capabilities = session.capabilities;
 
@@ -572,7 +572,7 @@ export default class Element extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	findDisplayed(using: string, value: string): Task<Element> {
+	findDisplayed(using: Strategy, value: string): Task<Element> {
 		return findDisplayed(this.session, this, using, value);
 	}
 
@@ -588,7 +588,7 @@ export default class Element extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	waitForDeleted(strategy: string, value: string) {
+	waitForDeleted(strategy: Strategy, value: string) {
 		return waitForDeleted(this.session, this, strategy, value);
 	}
 }

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -4,7 +4,7 @@ import findDisplayed from './lib/findDisplayed';
 import { partial } from '@dojo/core/lang';
 import Task from '@dojo/core/async/Task';
 import statusCodes from './lib/statusCodes';
-import Locator, { toW3cLocator } from './lib/Locator';
+import Locator, { toW3cLocator, Strategy } from './lib/Locator';
 import { forCommand as utilForCommand, sleep, toExecuteString } from './lib/util';
 import waitForDeleted from './lib/waitForDeleted';
 import { Capabilities, Geolocation, LogEntry, WebDriverCookie, WebDriverResponse } from './interfaces';
@@ -873,7 +873,7 @@ export default class Session extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * The strategy-specific value to search for. For example, if `using` is 'id', `value` should be the ID of the
 	 * element to retrieve.
 	 */
-	find(using: string, value: string) {
+	find(using: Strategy, value: string) {
 		if (this.capabilities.isWebDriver) {
 			const locator = toW3cLocator(using, value);
 			using = locator.using;
@@ -917,7 +917,7 @@ export default class Session extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param {string} value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	findAll(using: string, value: string) {
+	findAll(using: Strategy, value: string) {
 		if (this.capabilities.isWebDriver) {
 			const locator = toW3cLocator(using, value);
 			using = locator.using;
@@ -1648,7 +1648,7 @@ export default class Session extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	findDisplayed(using: string, value: string) {
+	findDisplayed(using: Strategy, value: string) {
 		return findDisplayed(this, this, using, value);
 	}
 
@@ -1661,8 +1661,8 @@ export default class Session extends Locator<Task<Element>, Task<Element[]>, Tas
 	 * @param value
 	 * The strategy-specific value to search for. See [[Session.find]] for details.
 	 */
-	waitForDeleted(strategy: string, value: string) {
-		return waitForDeleted(this, this, strategy, value);
+	waitForDeleted(using: Strategy, value: string) {
+		return waitForDeleted(this, this, using, value);
 	}
 
 	/**

--- a/src/lib/Locator.ts
+++ b/src/lib/Locator.ts
@@ -9,13 +9,13 @@
  *   4. xpath
  */
 abstract class Locator<E, L, V> {
-	abstract find(strategy: Strategies, value: string): E;
+	abstract find(strategy: Strategy, value: string): E;
 
-	abstract findAll(strategy: Strategies, value: string): L;
+	abstract findAll(strategy: Strategy, value: string): L;
 
-	abstract findDisplayed(strategy: Strategies, value: string): E;
+	abstract findDisplayed(strategy: Strategy, value: string): E;
 
-	abstract waitForDeleted(strategy: Strategies, value: string): V;
+	abstract waitForDeleted(strategy: Strategy, value: string): V;
 
 	/**
 	 * Gets the first element inside this element matching the given CSS class name.
@@ -325,20 +325,32 @@ abstract class Locator<E, L, V> {
 
 export default Locator;
 
-export const strategies = {
-	'class name': true,
+export const w3cStrategies = {
 	'css selector': true,
-	'id': true,
-	'name': true,
 	'link text': true,
 	'partial link text': true,
-	'tag name': true,
 	'xpath': true
 };
 
-export type Strategies = keyof typeof strategies;
+export type W3cStrategy = keyof typeof w3cStrategies;
 
-export function toW3cLocator(using: string, value: string) {
+export interface W3cLocator {
+	using: W3cStrategy;
+	value: string;
+}
+
+export const strategies = {
+	...w3cStrategies,
+	'class name': true,
+	'id': true,
+	'name': true,
+	'partial link text': true,
+	'tag name': true
+};
+
+export type Strategy = keyof typeof strategies;
+
+export function toW3cLocator(using: Strategy, value: string): W3cLocator {
 	switch (using) {
 		case 'id':
 			using = 'css selector';

--- a/src/lib/findDisplayed.ts
+++ b/src/lib/findDisplayed.ts
@@ -3,7 +3,9 @@ import statusCodes from './statusCodes';
 import Element from '../Element';
 import Session from '../Session';
 
-export default function findDisplayed(session: Session, locator: Session | Element, strategy: string, value: string) {
+import { Strategy } from './Locator';
+
+export default function findDisplayed(session: Session, locator: Session | Element, strategy: Strategy, value: string) {
 	return session.getTimeout('implicit').then(originalTimeout => {
 		const startTime = Date.now();
 

--- a/src/lib/waitForDeleted.ts
+++ b/src/lib/waitForDeleted.ts
@@ -3,7 +3,9 @@ import statusCodes from './statusCodes';
 import Session from '../Session';
 import Element from '../Element';
 
-export default function waitForDeleted(session: Session, locator: Session | Element, strategy: string, value: string) {
+import { Strategy } from './Locator';
+
+export default function waitForDeleted(session: Session, locator: Session | Element, using: Strategy, value: string) {
 	let originalTimeout: number;
 
 	return session.getTimeout('implicit').then(function (value) {
@@ -27,7 +29,7 @@ export default function waitForDeleted(session: Session, locator: Session | Elem
 					return;
 				}
 
-				locator.find(strategy, value).then(poll, function (error) {
+				locator.find(using, value).then(poll, function (error) {
 					const always = function () {
 						/* istanbul ignore else: other errors should never occur during normal operation */
 						if (error.name === 'NoSuchElement') {


### PR DESCRIPTION
Currently, the type for the strings of different strategies is called `Strategies`. All other types within Leadfoot are singular. I have renamed `Strategies` to `Strategy`. I also noticed that `find()`, `findAll()`, `findDisplayed()` and `waitForDeleted()` were not using the type so I have updated them as well.