### PR TITLE
Use `importHelpers` and add `tslib` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "leadfoot",
+  "name": "@theintern/leadfoot",
   "version": "2.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@dojo/interfaces": "~2.0.0-beta2.2",
     "@dojo/shim": "~2.0.0-beta2.2",
     "@theintern/dev": "~0.4.2",
-    "jszip": "~3.1.3"
+    "jszip": "~3.1.3",
+    "tslib": "^1.7.1"
   },
   "devDependencies": {
     "@dojo/loader": "~2.0.0-beta2.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
TypeScript 2.1 introduced the ability to import the helper functions (like `__extends` and `__decorate`) from an external library instead of emitting the helpers into each file that uses them. I've updated `tsconfig.json` to enable `importHelpers` and added `tslib` as a dependency of the project.