### PR TITLE
Fix W3C WebDriver API detection for IE

### DIFF
--- a/docs/api.json
+++ b/docs/api.json
@@ -15,7 +15,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/Command.ts",
+			"originalName": "src\\Command.ts",
 			"children": [
 				{
 					"id": 1201,
@@ -9605,7 +9605,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1298,
 									"character": 19
 								}
@@ -9695,7 +9695,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1139,
 									"character": 10
 								}
@@ -9748,7 +9748,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.iterable.d.ts",
 									"line": 52,
 									"character": 21
 								}
@@ -9800,7 +9800,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 95,
 															"character": 18
 														}
@@ -9820,7 +9820,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 96,
 															"character": 15
 														}
@@ -9840,7 +9840,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 97,
 															"character": 12
 														}
@@ -9860,7 +9860,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 98,
 															"character": 12
 														}
@@ -9880,7 +9880,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 99,
 															"character": 17
 														}
@@ -9900,7 +9900,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 100,
 															"character": 12
 														}
@@ -9920,7 +9920,7 @@
 													},
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 															"line": 101,
 															"character": 14
 														}
@@ -9948,7 +9948,7 @@
 											],
 											"sources": [
 												{
-													"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+													"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 													"line": 94,
 													"character": 27
 												}
@@ -9963,7 +9963,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.symbol.wellknown.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.symbol.wellknown.d.ts",
 									"line": 94,
 									"character": 24
 								}
@@ -10097,12 +10097,12 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1161,
 									"character": 10
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1166,
 									"character": 10
 								}
@@ -10205,7 +10205,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 									"line": 64,
 									"character": 14
 								}
@@ -10263,7 +10263,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.iterable.d.ts",
 									"line": 57,
 									"character": 11
 								}
@@ -10377,7 +10377,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1226,
 															"character": 21
 														}
@@ -10415,7 +10415,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1226,
 									"character": 9
 								}
@@ -10528,7 +10528,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 									"line": 53,
 									"character": 8
 								}
@@ -10657,7 +10657,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1250,
 															"character": 35
 														}
@@ -10793,7 +10793,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1256,
 															"character": 22
 														}
@@ -10834,12 +10834,12 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1250,
 									"character": 10
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1256,
 									"character": 10
 								}
@@ -10981,7 +10981,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 															"line": 31,
 															"character": 32
 														}
@@ -11117,7 +11117,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 															"line": 32,
 															"character": 19
 														}
@@ -11161,12 +11161,12 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 									"line": 31,
 									"character": 8
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 									"line": 32,
 									"character": 8
 								}
@@ -11280,7 +11280,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 															"line": 43,
 															"character": 24
 														}
@@ -11318,7 +11318,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.core.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.core.d.ts",
 									"line": 43,
 									"character": 13
 								}
@@ -11432,7 +11432,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1238,
 															"character": 23
 														}
@@ -11470,7 +11470,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1238,
 									"character": 11
 								}
@@ -11557,7 +11557,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1214,
 									"character": 11
 								}
@@ -11628,7 +11628,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1171,
 									"character": 8
 								}
@@ -11677,7 +11677,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.iterable.d.ts",
 									"line": 62,
 									"character": 8
 								}
@@ -11764,7 +11764,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1220,
 									"character": 15
 								}
@@ -11889,7 +11889,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1244,
 															"character": 22
 														}
@@ -11930,7 +11930,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1244,
 									"character": 7
 								}
@@ -11982,7 +11982,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1151,
 									"character": 7
 								}
@@ -12047,7 +12047,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1156,
 									"character": 8
 								}
@@ -12174,7 +12174,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1262,
 															"character": 22
 														}
@@ -12293,7 +12293,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1263,
 															"character": 22
 														}
@@ -12442,7 +12442,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1269,
 															"character": 25
 														}
@@ -12479,17 +12479,17 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1262,
 									"character": 10
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1263,
 									"character": 10
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1269,
 									"character": 10
 								}
@@ -12616,7 +12616,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1275,
 															"character": 27
 														}
@@ -12735,7 +12735,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1276,
 															"character": 27
 														}
@@ -12884,7 +12884,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1282,
 															"character": 30
 														}
@@ -12921,17 +12921,17 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1275,
 									"character": 15
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1276,
 									"character": 15
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1282,
 									"character": 15
 								}
@@ -12977,7 +12977,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1175,
 									"character": 11
 								}
@@ -13029,7 +13029,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1179,
 									"character": 9
 								}
@@ -13129,7 +13129,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1185,
 									"character": 9
 								}
@@ -13243,7 +13243,7 @@
 													],
 													"sources": [
 														{
-															"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+															"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 															"line": 1232,
 															"character": 20
 														}
@@ -13281,7 +13281,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1232,
 									"character": 8
 								}
@@ -13403,7 +13403,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1190,
 									"character": 8
 								}
@@ -13570,12 +13570,12 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1196,
 									"character": 10
 								},
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1203,
 									"character": 10
 								}
@@ -13618,7 +13618,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1147,
 									"character": 18
 								}
@@ -13661,7 +13661,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1143,
 									"character": 12
 								}
@@ -13726,7 +13726,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 1208,
 									"character": 11
 								}
@@ -13775,7 +13775,7 @@
 							],
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es2015.iterable.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es2015.iterable.d.ts",
 									"line": 67,
 									"character": 10
 								}
@@ -14083,7 +14083,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/Element.ts",
+			"originalName": "src\\Element.ts",
 			"children": [
 				{
 					"id": 1025,
@@ -18016,7 +18016,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/Server.ts",
+			"originalName": "src\\Server.ts",
 			"children": [
 				{
 					"id": 307,
@@ -18459,7 +18459,7 @@
 							"sources": [
 								{
 									"fileName": "Server.ts",
-									"line": 1821,
+									"line": 1829,
 									"character": 15
 								}
 							]
@@ -18611,7 +18611,7 @@
 							"sources": [
 								{
 									"fileName": "Server.ts",
-									"line": 1814,
+									"line": 1822,
 									"character": 24
 								}
 							]
@@ -18656,7 +18656,7 @@
 							"sources": [
 								{
 									"fileName": "Server.ts",
-									"line": 1788,
+									"line": 1796,
 									"character": 13
 								}
 							]
@@ -18860,7 +18860,7 @@
 							"sources": [
 								{
 									"fileName": "Server.ts",
-									"line": 1986,
+									"line": 1994,
 									"character": 6
 								}
 							],
@@ -18880,7 +18880,7 @@
 							"sources": [
 								{
 									"fileName": "Server.ts",
-									"line": 1985,
+									"line": 1993,
 									"character": 10
 								}
 							],
@@ -18903,7 +18903,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1984,
+							"line": 1992,
 							"character": 22
 						}
 					]
@@ -18956,7 +18956,7 @@
 													"sources": [
 														{
 															"fileName": "Server.ts",
-															"line": 1826,
+															"line": 1834,
 															"character": 51
 														}
 													],
@@ -18982,7 +18982,7 @@
 																	"sources": [
 																		{
 																			"fileName": "Server.ts",
-																			"line": 1826,
+																			"line": 1834,
 																			"character": 60
 																		}
 																	],
@@ -19004,7 +19004,7 @@
 															"sources": [
 																{
 																	"fileName": "Server.ts",
-																	"line": 1826,
+																	"line": 1834,
 																	"character": 52
 																}
 															]
@@ -19022,7 +19022,7 @@
 													"sources": [
 														{
 															"fileName": "Server.ts",
-															"line": 1826,
+															"line": 1834,
 															"character": 35
 														}
 													],
@@ -19045,7 +19045,7 @@
 											"sources": [
 												{
 													"fileName": "Server.ts",
-													"line": 1826,
+													"line": 1834,
 													"character": 28
 												}
 											]
@@ -19062,7 +19062,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1826,
+							"line": 1834,
 							"character": 21
 						}
 					]
@@ -19109,7 +19109,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1854,
+							"line": 1862,
 							"character": 18
 						}
 					]
@@ -19156,7 +19156,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1859,
+							"line": 1867,
 							"character": 26
 						}
 					]
@@ -19249,7 +19249,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1864,
+							"line": 1872,
 							"character": 17
 						}
 					]
@@ -19343,7 +19343,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1929,
+							"line": 1937,
 							"character": 25
 						}
 					]
@@ -19437,7 +19437,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1903,
+							"line": 1911,
 							"character": 34
 						}
 					]
@@ -19484,7 +19484,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1876,
+							"line": 1884,
 							"character": 14
 						}
 					]
@@ -19531,7 +19531,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1881,
+							"line": 1889,
 							"character": 14
 						}
 					]
@@ -19625,7 +19625,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1890,
+							"line": 1898,
 							"character": 24
 						}
 					]
@@ -19719,7 +19719,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1916,
+							"line": 1924,
 							"character": 24
 						}
 					]
@@ -19815,7 +19815,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1947,
+							"line": 1955,
 							"character": 23
 						}
 					]
@@ -19846,7 +19846,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1972,
+							"line": 1980,
 							"character": 13
 						}
 					]
@@ -19899,7 +19899,7 @@
 					"sources": [
 						{
 							"fileName": "Server.ts",
-							"line": 1980,
+							"line": 1988,
 							"character": 20
 						}
 					]
@@ -19957,7 +19957,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/Session.ts",
+			"originalName": "src\\Session.ts",
 			"children": [
 				{
 					"id": 560,
@@ -28361,7 +28361,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 914,
 									"character": 19
 								}
@@ -28381,7 +28381,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 904,
 									"character": 11
 								}
@@ -28405,7 +28405,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 903,
 									"character": 8
 								}
@@ -28430,7 +28430,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 905,
 									"character": 9
 								}
@@ -29885,7 +29885,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/helpers/pollUntil.ts",
+			"originalName": "src\\helpers\\pollUntil.ts",
 			"children": [
 				{
 					"id": 1869,
@@ -31683,7 +31683,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/helpers/pollUntilTruthy.ts",
+			"originalName": "src\\helpers\\pollUntilTruthy.ts",
 			"children": [
 				{
 					"id": 1978,
@@ -33467,7 +33467,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/index.ts",
+			"originalName": "src\\index.ts",
 			"sources": [
 				{
 					"fileName": "index.ts",
@@ -33485,7 +33485,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/interfaces.ts",
+			"originalName": "src\\interfaces.ts",
 			"children": [
 				{
 					"id": 174,
@@ -36984,7 +36984,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 914,
 									"character": 19
 								}
@@ -37005,7 +37005,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 904,
 									"character": 11
 								}
@@ -37030,7 +37030,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 903,
 									"character": 8
 								}
@@ -37126,7 +37126,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/typescript/lib/lib.es5.d.ts",
+									"fileName": "node_modules\\typescript\\lib\\lib.es5.d.ts",
 									"line": 905,
 									"character": 9
 								}
@@ -37234,7 +37234,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2407,
 									"character": 12
 								}
@@ -37269,7 +37269,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2408,
 									"character": 12
 								}
@@ -37304,7 +37304,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2409,
 									"character": 12
 								}
@@ -37339,7 +37339,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2410,
 									"character": 16
 								}
@@ -37374,7 +37374,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2411,
 									"character": 12
 								}
@@ -37440,7 +37440,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2412,
 									"character": 12
 								}
@@ -37475,7 +37475,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2413,
 									"character": 16
 								}
@@ -37510,7 +37510,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2427,
 									"character": 12
 								}
@@ -37545,7 +37545,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2414,
 									"character": 16
 								}
@@ -37580,7 +37580,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2428,
 									"character": 13
 								}
@@ -37619,7 +37619,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2415,
 									"character": 14
 								}
@@ -37654,7 +37654,7 @@
 							},
 							"sources": [
 								{
-									"fileName": "node_modules/@types/node/index.d.ts",
+									"fileName": "node_modules\\@types\\node\\index.d.ts",
 									"line": 2416,
 									"character": 15
 								}
@@ -38132,7 +38132,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/keys.ts",
+			"originalName": "src\\keys.ts",
 			"children": [
 				{
 					"id": 59,
@@ -40967,7 +40967,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/lib/Locator.ts",
+			"originalName": "src\\lib\\Locator.ts",
 			"children": [
 				{
 					"id": 408,
@@ -43781,7 +43781,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/lib/findDisplayed.ts",
+			"originalName": "src\\lib\\findDisplayed.ts",
 			"children": [
 				{
 					"id": 1018,
@@ -43919,7 +43919,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/lib/statusCodes.ts",
+			"originalName": "src\\lib\\statusCodes.ts",
 			"children": [
 				{
 					"id": 31,
@@ -44659,7 +44659,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/lib/util.ts",
+			"originalName": "src\\lib\\util.ts",
 			"children": [
 				{
 					"id": 5,
@@ -45246,7 +45246,7 @@
 				"isExported": true,
 				"__visited__": true
 			},
-			"originalName": "src/lib/waitForDeleted.ts",
+			"originalName": "src\\lib\\waitForDeleted.ts",
 			"children": [
 				{
 					"id": 553,

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -748,6 +748,14 @@ export default class Server {
         0,
         9
       );
+
+      // The IEDriverServer.exe switched from JWP to W3C (in 3.12).  In the
+      // W3C version, the object returned by the "/session" command contains
+      // value.capabilities rather than the value object being the capabilities
+      // object and the capabilities object contains an "se:ieOptions" property.
+      if (capabilities['se:ieOptions']) {
+        updates.usesWebDriverExecuteSync = true;
+      }
     }
 
     // Don't check for touch support if the environment reports that no


### PR DESCRIPTION
Around version 3.12 of the IE WebDriver server (IEDriverServer.exe), it switch to using the W3C API.  I added code to detect that switch.

Needed in https://github.com/theintern/digdug/pull/73.